### PR TITLE
feat(ohmyposh): Migrate to ohmyposh

### DIFF
--- a/.config/ohmyposh/config.omp.json
+++ b/.config/ohmyposh/config.omp.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "version": 2,
+  "final_space": true,
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "os",
+          "style": "plain",
+          "foreground": "p:os",
+          "template": "{{.Icon}} "
+        },
+        {
+          "type": "session",
+          "style": "plain",
+          "foreground": "p:blue",
+          "template": "{{ .UserName }}@{{ .HostName }} "
+        },
+        {
+          "type": "path",
+          "style": "plain",
+          "foreground": "p:pink",
+          "template": "{{ .Path }} ",
+          "properties": {
+            "folder_icon": "..\ue5fe..",
+            "home_icon": "~",
+            "style": "agnoster_short"
+          }
+        },
+        {
+          "type": "git",
+          "style": "plain",
+          "foreground": "p:lavender",
+          "template": "{{ .HEAD }} ",
+          "properties": {
+            "branch_icon": "\ue725 ",
+            "cherry_pick_icon": "\ue29b ",
+            "commit_icon": "\uf417 ",
+            "fetch_status": false,
+            "fetch_upstream_icon": false,
+            "merge_icon": "\ue727 ",
+            "no_commits_icon": "\uf0c3 ",
+            "rebase_icon": "\ue728 ",
+            "revert_icon": "\uf0e2 ",
+            "tag_icon": "\uf412 "
+          }
+        },
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "p:closer",
+          "template": "\uf105"
+        }
+      ]
+    }
+  ],
+  "palette": {
+    "blue": "#89B4FA",
+    "closer": "p:os",
+    "lavender": "#B4BEFE",
+    "os": "#ACB0BE",
+    "pink": "#F5C2E7"
+  }
+}

--- a/.config/ohmyposh/config.omp.json
+++ b/.config/ohmyposh/config.omp.json
@@ -57,6 +57,11 @@
       ]
     }
   ],
+  "transient_prompt": {
+    "background": "transparent",
+    "foreground": "p:os",
+    "template": "{{ .Folder }}> "
+  },
   "palette": {
     "blue": "#89B4FA",
     "closer": "p:os",

--- a/.zshrc
+++ b/.zshrc
@@ -105,6 +105,7 @@ source $ZSH/oh-my-zsh.sh
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 #
 # https://ohmyposh.dev/docs/installation/prompt
+# https://ohmyposh.dev/docs/installation/customize
 if [ "$TERM_PROGRAM" != "Apple_Terminal" ]; then
   eval "$(oh-my-posh init zsh --config $HOME/.config/ohmyposh/config.omp.json)"
 fi

--- a/.zshrc
+++ b/.zshrc
@@ -1,10 +1,3 @@
-# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
-# Initialization code that may require console input (password prompts, [y/n]
-# confirmations, etc.) must go above this block; everything else may go below.
-if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
-  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
-fi
-
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
 
@@ -15,7 +8,6 @@ export ZSH="$HOME/.oh-my-zsh"
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-ZSH_THEME="powerlevel10k/powerlevel10k"
 source ~/.config/zsh/themes/catppuccin_mocha-zsh-syntax-highlighting.zsh
 
 # Set list of themes to pick from when loading at random
@@ -111,6 +103,11 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+#
+# https://ohmyposh.dev/docs/installation/prompt
+if [ "$TERM_PROGRAM" != "Apple_Terminal" ]; then
+  eval "$(oh-my-posh init zsh --config $HOME/.config/ohmyposh/config.omp.json)"
+fi
 
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
 export SDKMAN_DIR="$HOME/.sdkman"
@@ -120,9 +117,6 @@ export PATH=/opt/homebrew/bin:~/go/bin:$PATH
 
 # Generated for envman. Do not edit.
 [ -s "$HOME/.config/envman/load.sh" ] && source "$HOME/.config/envman/load.sh"
-
-# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
-[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
 HISTFILE=$HOME/.zhistory
 SAVEHIST=1000

--- a/brew-install.sh
+++ b/brew-install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+brew install jandedobbeleer/oh-my-posh/oh-my-posh


### PR DESCRIPTION
- **feat(ohmyposh): Init with catppuccin_mocha theme**
- **feat(ohmyposh): Add Transient prompts**
- **ci: Add brew install script**

## References 
- [We may have killed p10k, so I found the perfect replacement.](https://www.youtube.com/watch?v=9U8LCjuQzdc)
- [JanDeDobbeleer/oh-my-posh: The most customisable and low-latency cross platform/shell prompt renderer](https://github.com/jandedobbeleer/oh-my-posh)
- [macOS | Oh My Posh](https://ohmyposh.dev/docs/installation/macos)
- [Customize | Oh My Posh](https://ohmyposh.dev/docs/installation/customize)
- [oh-my-posh/themes/catppuccin_mocha.omp.json at main · JanDeDobbeleer/oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/catppuccin_mocha.omp.json)
- [What is the preferred Bash shebang ("#!")? - Stack Overflow](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang)